### PR TITLE
Spec: Support multiple users in the CLI

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,271 @@
+# Specification: Multi-User Support for Secure Notes CLI
+
+## 1. Overview
+
+**Issue:** Support multiple users in the CLI  
+**Description:** Currently the CLI only supports a single user. This spec outlines adding the ability for multiple users to have their own notes, with each user having their own password-protected vault.
+
+## 2. Problem Statement
+
+The current implementation:
+- Stores all notes in a single database at `~/.secure-notes/notes.db`
+- Uses a single master password for the entire application
+- Has no concept of user identity or isolation
+- All notes are accessible to anyone who knows the master password
+
+This approach does not support:
+- Multiple family members sharing the same machine
+- Multiple projects or contexts requiring separate note stores
+- Privacy between different users on the same system
+
+## 3. Solution Overview
+
+Introduce a user management system where:
+- Each user has their own encrypted vault
+- Users are identified by username
+- Each user has their own password
+- Notes are associated with users via foreign key
+- The system maintains a "current user" context
+- Switching users requires re-authentication
+
+## 4. Database Schema Changes
+
+### 4.1 New Tables
+
+```sql
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  last_login INTEGER
+);
+
+-- Track current active user
+CREATE TABLE IF NOT EXISTS active_user (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  user_id INTEGER,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Notes now reference users
+ALTER TABLE notes ADD COLUMN user_id INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE notes ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+```
+
+### 4.2 Migration Strategy
+
+- Create migration system to upgrade existing single-user database
+- Existing notes will be migrated to user_id = 1 (default user)
+- Create a default user "default" with existing password
+
+## 5. New Commands
+
+### 5.1 User Management Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `user add <username>` | Create a new user | `secure-notes user add alice` |
+| `user switch <username>` | Switch to another user | `secure-notes user switch alice` |
+| `user list` | List all users | `secure-notes user list` |
+| `user delete <username>` | Delete a user and their notes | `secure-notes user delete alice` |
+| `user current` | Show current user | `secure-notes user current` |
+
+### 5.2 Command Modifications
+
+All existing commands should work with the current user's context:
+- `init`: Creates the first user (renamed behavior)
+- `unlock`: Authenticates the current user
+- `lock`: Locks current user's session
+- Other commands (add, list, show, etc.): Work on current user's notes only
+
+## 6. Data Storage Structure
+
+```
+~/.secure-notes/
+├── config.json          # App-level config (editor, autolock)
+├── notes.db             # SQLite database (shared)
+└── sessions/            # Session files per user
+    ├── default.session
+    ├── alice.session
+    └── bob.session
+```
+
+Alternatively, use subdirectories per user:
+```
+~/.secure-notes/
+├── config.json
+├── default/
+│   ├── notes.db
+│   └── session
+├── alice/
+│   ├── notes.db
+│   └── session
+└── bob/
+    ├── notes.db
+    └── session
+```
+
+**Decision:** Use per-user database directories for better isolation. Each user gets their own `notes.db` file.
+
+## 7. API/Implementation Details
+
+### 7.1 User Repository
+
+```typescript
+interface User {
+  id: number;
+  username: string;
+  password_hash: string;
+  created_at: number;
+  last_login: number | null;
+}
+
+class UserRepository {
+  createUser(username: string, password: string): User
+  getUserByUsername(username: string): User | null
+  getUserById(id: number): User | null
+  getAllUsers(): User[]
+  deleteUser(username: string): boolean
+  updateLastLogin(userId: number): void
+}
+```
+
+### 7.2 Active User Management
+
+```typescript
+class ActiveUserRepository {
+  setActiveUser(userId: number): void
+  getActiveUser(): User | null
+  clearActiveUser(): void
+}
+```
+
+### 7.3 Database Path Resolution
+
+```typescript
+function getUserDatabasePath(username: string): string {
+  const BASE_DIR = process.env.SECURE_NOTES_HOME || join(homedir(), '.secure-notes');
+  return join(BASE_DIR, username, 'notes.db');
+}
+
+function ensureUserDatabaseDir(username: string): void {
+  const dir = join(getBaseDir(), username);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+}
+```
+
+## 8. Security Considerations
+
+1. **Password Storage**: Use bcrypt/argon2 for password hashing
+2. **Directory Permissions**: Each user directory should be `0700` (owner only)
+3. **Session Isolation**: Sessions are per-user, not global
+4. **User Deletion**: When deleting a user, cascade delete their notes and directory
+
+## 9. Backward Compatibility
+
+- Single-user installations should continue to work
+- Migration script will detect single-user setup and convert automatically
+- Default user "default" will be created for existing installations
+- CLI should work without modification for single-user scenarios
+
+## 10. User Experience
+
+### 10.1 First Run (New Multi-User Setup)
+
+```
+$ secure-notes init
+Welcome to Secure Notes!
+Creating a new vault. This will be the admin user.
+
+Enter username: alice
+Create a master password: ********
+Confirm master password: ********
+
+✓ Vault initialized
+✓ Logged in as alice
+```
+
+### 10.2 Adding a New User
+
+```
+$ secure-notes user add bob
+Enter username: bob
+Create a master password: ********
+Confirm master password: ********
+
+✓ User bob created
+```
+
+### 10.3 Switching Users
+
+```
+$ secure-notes user switch bob
+Enter password for bob: ********
+
+✓ Switched to user bob
+```
+
+### 10.4 Listing Notes (User-Specific)
+
+```
+$ secure-notes list
+Notes for alice:
+1. Grocery List (encrypted)
+2. Meeting Notes
+
+$ secure-notes user switch bob
+$ secure-notes list
+Notes for bob:
+1. Project Ideas
+```
+
+## 11. Implementation Phases
+
+### Phase 1: Database & Core Infrastructure
+- Add users table to schema
+- Implement UserRepository
+- Implement ActiveUserRepository
+- Update database path resolution
+
+### Phase 2: User Management Commands
+- Implement `user add` command
+- Implement `user switch` command
+- Implement `user list` command
+- Implement `user delete` command
+- Implement `user current` command
+
+### Phase 3: Authentication Updates
+- Update unlock command for multi-user
+- Add user context to session management
+- Update lock command for multi-user
+
+### Phase 4: Migration & Backward Compatibility
+- Create migration script for existing databases
+- Test upgrade path
+- Verify single-user mode works
+
+### Phase 5: Testing & Documentation
+- Unit tests for new repositories
+- Integration tests for user workflows
+- Update README with multi-user documentation
+
+## 12. Acceptance Criteria
+
+1. ✓ Multiple users can be created with unique usernames and passwords
+2. ✓ Users can switch between accounts with authentication
+3. ✓ Each user can only see and modify their own notes
+4. ✓ Users can be deleted (with confirmation), removing all their notes
+5. ✓ Existing single-user installations can upgrade seamlessly
+6. ✓ Session management works correctly per user
+7. ✓ All existing commands (add, list, show, edit, delete, etc.) work with multi-user context
+8. ✓ Security is maintained (proper file permissions, password hashing)
+
+## 13. Open Questions
+
+- Should users be able to share notes with other users? (Out of scope for v1)
+- Should there be an admin user with ability to view all users? (Out of scope for v1)
+- How to handle password change for users? (Already covered by change-password command)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,271 +1,240 @@
-# Specification: Multi-User Support for Secure Notes CLI
+# Specification: Support Multiple Users in the CLI
 
-## 1. Overview
+## Issue
+- **Issue Number**: #5
+- **Issue Title**: Support multiple users in the CLI
 
-**Issue:** Support multiple users in the CLI  
-**Description:** Currently the CLI only supports a single user. This spec outlines adding the ability for multiple users to have their own notes, with each user having their own password-protected vault.
+## Problem Statement
+Currently, the CLI only supports a single user. All notes are stored in a single database and protected by a single master password. Users need the ability for multiple users to have their own separate notes, each with their own authentication and storage.
 
-## 2. Problem Statement
+## Summary of Changes Needed
+1. Add a new `users` table to store multiple users with their own credentials
+2. Modify the database schema to associate notes with users
+3. Update CLI commands to work with user-specific data
+4. Add user management commands (create user, switch user, list users, delete user)
+5. Update authentication to support multiple users
 
-The current implementation:
-- Stores all notes in a single database at `~/.secure-notes/notes.db`
-- Uses a single master password for the entire application
-- Has no concept of user identity or isolation
-- All notes are accessible to anyone who knows the master password
+## Detailed Specification
 
-This approach does not support:
-- Multiple family members sharing the same machine
-- Multiple projects or contexts requiring separate note stores
-- Privacy between different users on the same system
+### 1. Database Schema Changes
 
-## 3. Solution Overview
-
-Introduce a user management system where:
-- Each user has their own encrypted vault
-- Users are identified by username
-- Each user has their own password
-- Notes are associated with users via foreign key
-- The system maintains a "current user" context
-- Switching users requires re-authentication
-
-## 4. Database Schema Changes
-
-### 4.1 New Tables
-
+#### New Table: `users`
 ```sql
--- Users table
 CREATE TABLE IF NOT EXISTS users (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   username TEXT UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
   created_at INTEGER NOT NULL,
-  last_login INTEGER
+  updated_at INTEGER NOT NULL
 );
+```
 
--- Track current active user
-CREATE TABLE IF NOT EXISTS active_user (
+#### New Table: `user_session`
+```sql
+CREATE TABLE IF NOT EXISTS user_session (
   id INTEGER PRIMARY KEY CHECK (id = 1),
-  user_id INTEGER,
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+  current_user_id INTEGER,
+  unlocked_at INTEGER,
+  last_activity INTEGER,
+  FOREIGN KEY (current_user_id) REFERENCES users(id) ON DELETE SET NULL
 );
+```
 
--- Notes now reference users
+#### Modified Table: `notes`
+Add `user_id` column:
+```sql
 ALTER TABLE notes ADD COLUMN user_id INTEGER NOT NULL DEFAULT 1;
-ALTER TABLE notes ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+CREATE INDEX IF NOT EXISTS idx_notes_user_id ON notes(user_id);
 ```
 
-### 4.2 Migration Strategy
-
-- Create migration system to upgrade existing single-user database
-- Existing notes will be migrated to user_id = 1 (default user)
-- Create a default user "default" with existing password
-
-## 5. New Commands
-
-### 5.1 User Management Commands
-
-| Command | Description | Example |
-|---------|-------------|---------|
-| `user add <username>` | Create a new user | `secure-notes user add alice` |
-| `user switch <username>` | Switch to another user | `secure-notes user switch alice` |
-| `user list` | List all users | `secure-notes user list` |
-| `user delete <username>` | Delete a user and their notes | `secure-notes user delete alice` |
-| `user current` | Show current user | `secure-notes user current` |
-
-### 5.2 Command Modifications
-
-All existing commands should work with the current user's context:
-- `init`: Creates the first user (renamed behavior)
-- `unlock`: Authenticates the current user
-- `lock`: Locks current user's session
-- Other commands (add, list, show, etc.): Work on current user's notes only
-
-## 6. Data Storage Structure
-
-```
-~/.secure-notes/
-├── config.json          # App-level config (editor, autolock)
-├── notes.db             # SQLite database (shared)
-└── sessions/            # Session files per user
-    ├── default.session
-    ├── alice.session
-    └── bob.session
+#### Modified Table: `tags`
+Add `user_id` column:
+```sql
+ALTER TABLE tags ADD COLUMN user_id INTEGER NOT NULL DEFAULT 1;
+CREATE INDEX IF NOT EXISTS idx_tags_user_id ON tags(user_id);
 ```
 
-Alternatively, use subdirectories per user:
-```
-~/.secure-notes/
-├── config.json
-├── default/
-│   ├── notes.db
-│   └── session
-├── alice/
-│   ├── notes.db
-│   └── session
-└── bob/
-    ├── notes.db
-    └── session
+#### Modified Table: `note_tags`
+Update foreign keys to include user context through notes:
+```sql
+-- Note: note_tags already cascades through notes
 ```
 
-**Decision:** Use per-user database directories for better isolation. Each user gets their own `notes.db` file.
+### 2. Repository Changes
 
-## 7. API/Implementation Details
-
-### 7.1 User Repository
-
+#### UserRepository Class
 ```typescript
-interface User {
+export interface User {
   id: number;
   username: string;
   password_hash: string;
   created_at: number;
-  last_login: number | null;
+  updated_at: number;
 }
 
-class UserRepository {
-  createUser(username: string, password: string): User
-  getUserByUsername(username: string): User | null
+export class UserRepository {
+  createUser(username: string, passwordHash: string): User
   getUserById(id: number): User | null
+  getUserByUsername(username: string): User | null
   getAllUsers(): User[]
-  deleteUser(username: string): boolean
-  updateLastLogin(userId: number): void
+  updatePassword(id: number, passwordHash: string): boolean
+  deleteUser(id: number): boolean
 }
 ```
 
-### 7.2 Active User Management
+#### Updated NoteRepository
+- All note operations now accept optional `userId` parameter
+- Default to current user if not specified
+- Methods to update:
+  - `createNote(title, content, ...)` → add `userId`
+  - `getAllNotes()` → filter by `userId`
+  - `getNotesByTag(tagName, userId?)`
+  - `searchNotes(query, userId?)`
+  - `getNoteById(id)` → verify ownership
 
-```typescript
-class ActiveUserRepository {
-  setActiveUser(userId: number): void
-  getActiveUser(): User | null
-  clearActiveUser(): void
-}
+#### Updated TagRepository
+- Tags become user-specific (user's own tags)
+- `getTagsForNote(noteId, userId?)`
+
+#### Updated SessionRepository
+- Track current user in session
+- `setCurrentUser(userId)`
+- `getCurrentUser(): User | null`
+- `clearCurrentUser()`
+
+### 3. CLI Command Changes
+
+#### New Commands
+
+**`user-create`**
+```bash
+secure-notes user-create <username>
+# Prompts for password (min 8 chars)
+# Creates new user and switches to them
 ```
 
-### 7.3 Database Path Resolution
-
-```typescript
-function getUserDatabasePath(username: string): string {
-  const BASE_DIR = process.env.SECURE_NOTES_HOME || join(homedir(), '.secure-notes');
-  return join(BASE_DIR, username, 'notes.db');
-}
-
-function ensureUserDatabaseDir(username: string): void {
-  const dir = join(getBaseDir(), username);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
-}
+**`user-switch`**
+```bash
+secure-notes user-switch <username>
+# Requires password verification
+# Switches to specified user
 ```
 
-## 8. Security Considerations
-
-1. **Password Storage**: Use bcrypt/argon2 for password hashing
-2. **Directory Permissions**: Each user directory should be `0700` (owner only)
-3. **Session Isolation**: Sessions are per-user, not global
-4. **User Deletion**: When deleting a user, cascade delete their notes and directory
-
-## 9. Backward Compatibility
-
-- Single-user installations should continue to work
-- Migration script will detect single-user setup and convert automatically
-- Default user "default" will be created for existing installations
-- CLI should work without modification for single-user scenarios
-
-## 10. User Experience
-
-### 10.1 First Run (New Multi-User Setup)
-
-```
-$ secure-notes init
-Welcome to Secure Notes!
-Creating a new vault. This will be the admin user.
-
-Enter username: alice
-Create a master password: ********
-Confirm master password: ********
-
-✓ Vault initialized
-✓ Logged in as alice
+**`user-list`**
+```bash
+secure-notes user-list
+# Lists all users (just usernames, not passwords)
 ```
 
-### 10.2 Adding a New User
-
-```
-$ secure-notes user add bob
-Enter username: bob
-Create a master password: ********
-Confirm master password: ********
-
-✓ User bob created
+**`user-delete`**
+```bash
+secure-notes user-delete <username>
+# Confirms deletion
+# Deletes user and all their notes
+# Cannot delete last remaining user
 ```
 
-### 10.3 Switching Users
-
-```
-$ secure-notes user switch bob
-Enter password for bob: ********
-
-✓ Switched to user bob
+**`user-current`**
+```bash
+secure-notes user-current
+# Shows current user
 ```
 
-### 10.4 Listing Notes (User-Specific)
+#### Modified Commands
 
+**`init`** - Renamed behavior
+- First run: Creates default user "admin"
+- Subsequent runs: Error "already initialized"
+
+**`unlock`** - Changed behavior
+- Now unlocks for current user (not global)
+- User must be selected first via `user-switch`
+
+**`lock`** - Changed behavior
+- Locks current user's session
+
+**`add`** - Added implicit user context
+- Notes created for current user
+
+**`list`** - Added implicit user context
+- Only lists notes for current user
+- New option: `--all-users` to list all users' notes (admin only)
+
+**`show`, `edit`, `delete`** - Ownership check
+- Verify note belongs to current user
+- Error if trying to access another user's note
+
+**`search`** - Added implicit user context
+- Only searches current user's notes
+
+**`tag`, `untag`** - Added implicit user context
+
+**`config`** - User-specific config
+- Config stored per-user in `user_config` table
+
+### 4. New Configuration Storage
+
+#### Table: `user_config`
+```sql
+CREATE TABLE IF NOT EXISTS user_config (
+  user_id INTEGER NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT,
+  PRIMARY KEY (user_id, key),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
 ```
-$ secure-notes list
-Notes for alice:
-1. Grocery List (encrypted)
-2. Meeting Notes
 
-$ secure-notes user switch bob
-$ secure-notes list
-Notes for bob:
-1. Project Ideas
-```
+### 5. Data Migration
 
-## 11. Implementation Phases
+On first run with multi-user code:
+1. Check if old single-user database exists
+2. If yes, migrate:
+   - Create "admin" user from existing master_password
+   - Add user_id = 1 to all existing notes
+   - Add user_id = 1 to all existing tags
+3. If no, create fresh database with "admin" user
 
-### Phase 1: Database & Core Infrastructure
-- Add users table to schema
-- Implement UserRepository
-- Implement ActiveUserRepository
-- Update database path resolution
+### 6. Security Considerations
 
-### Phase 2: User Management Commands
-- Implement `user add` command
-- Implement `user switch` command
-- Implement `user list` command
-- Implement `user delete` command
-- Implement `user current` command
+1. **User Isolation**: Users can only see/modify their own notes
+2. **Password Hashing**: Each user has their own Argon2id hash
+3. **Session Isolation**: Each user has separate unlock state
+4. **Admin Role**: First user created is "admin" but no special privileges initially
+5. **Deletion Safety**: Cannot delete last user (at least one must exist)
 
-### Phase 3: Authentication Updates
-- Update unlock command for multi-user
-- Add user context to session management
-- Update lock command for multi-user
+### 7. Backward Compatibility
 
-### Phase 4: Migration & Backward Compatibility
-- Create migration script for existing databases
-- Test upgrade path
-- Verify single-user mode works
+- Single-user mode: Works exactly as before (implicit user "admin")
+- Migration: Automatic, no data loss
+- CLI: Most existing commands work with minimal changes
 
-### Phase 5: Testing & Documentation
-- Unit tests for new repositories
-- Integration tests for user workflows
-- Update README with multi-user documentation
+### 8. Implementation Priority
 
-## 12. Acceptance Criteria
+1. Database schema changes
+2. UserRepository implementation
+3. Updated SessionRepository with user context
+4. Update NoteRepository for user filtering
+5. User commands (create, switch, list, delete, current)
+6. Update all note commands to use user context
+7. Migration logic for existing data
+8. Tests
 
-1. ✓ Multiple users can be created with unique usernames and passwords
-2. ✓ Users can switch between accounts with authentication
-3. ✓ Each user can only see and modify their own notes
-4. ✓ Users can be deleted (with confirmation), removing all their notes
-5. ✓ Existing single-user installations can upgrade seamlessly
-6. ✓ Session management works correctly per user
-7. ✓ All existing commands (add, list, show, edit, delete, etc.) work with multi-user context
-8. ✓ Security is maintained (proper file permissions, password hashing)
+### 9. File Changes
 
-## 13. Open Questions
+- `src/db/database.ts`: Add new tables
+- `src/db/repository.ts`: Add UserRepository, update other repositories
+- `src/utils/session.ts`: Update for user context
+- `src/index.ts`: Add user commands
+- `src/commands/user.ts`: New file for user management commands
+- `src/commands/init.ts`: Update for first-run user creation
+- `src/commands/unlock.ts`: Update for user-specific unlock
+- `src/commands/add.ts`, `list.ts`, `show.ts`, `edit.ts`, `delete.ts`, `search.ts`, `tag.ts`: Update for user context
 
-- Should users be able to share notes with other users? (Out of scope for v1)
-- Should there be an admin user with ability to view all users? (Out of scope for v1)
-- How to handle password change for users? (Already covered by change-password command)
+### 10. Testing Requirements
+
+- Unit tests for UserRepository
+- Integration tests for user creation/switching
+- Note operations with user isolation
+- Migration from single-user to multi-user
+- CLI command tests for new user commands


### PR DESCRIPTION
## Summary

This PR adds a detailed specification for implementing multi-user support in the Secure Notes CLI.

## Issue
- **Issue #5**: Support multiple users in the CLI
- Currently the CLI only supports a single user with a master password
- Need to add ability for multiple users to have their own notes

## Specification Overview

### Key Changes

1. **Database Schema Changes**:
   - Add stephen table for user accounts
   - Add  table to track session and current user
   - Add  foreign key to  table
   - Add user_id to  table for per-user settings

2. **New Commands**:
   -  - Create new user account
   -  - Switch to different user
   -  - List all users (admin)
   -  - Delete user and their notes
   - Changing password for stephen. - Change user password

3. **Modified Commands**:
   -  - Creates initial user with username
   -  - Authenticates specific user
   - All note commands - Filter by current user

### Security
- Each user has their own Argon2id-hashed password
- Notes are isolated per user
- Sessions track current user
- Config is per-user

### Backward Compatibility
- Existing installations migrate automatically
- Creates "default" user from existing data
- No breaking changes for single-user installations

See [SPEC.md](SPEC.md) for the complete specification.